### PR TITLE
Make non mandatory BottomNavigation

### DIFF
--- a/src/Paper__BottomNavigation.res
+++ b/src/Paper__BottomNavigation.res
@@ -2,10 +2,10 @@ type route = {
   "key": string,
   "title": string,
   "icon": string,
-  "color": string,
-  "badge": string,
-  "accessibilityLabel": string,
-  "testID": string,
+  "color": option<string>,
+  "badge": option<string>,
+  "accessibilityLabel": option<string>,
+  "testID": option<string>,
 }
 
 type jumpTo = string => unit


### PR DESCRIPTION
Enables to use the BottomNavigation with no badges.
In the present state, is you put an empty string for a badge like this: 

```
{
    "key": "account",
    "title": "account",
    "icon": "credit-card",
    "color": "blue",
    "badge": "",
    "accessibilityLabel": "myLabel",
    "testID": "myId",
  }

```

You get this unexpected behavior:

<img width="138" alt="Capture d’écran 2022-03-25 à 16 38 09" src="https://user-images.githubusercontent.com/19576344/160153013-119c99aa-dd53-46db-8a13-2e7938c987e6.png">

Now you can just do 
```
{
    "key": "account",
    "title": "account",
    "icon": "credit-card",
    "color": "blue",
    "badge": None,
    "accessibilityLabel": "myLabel",
    "testID": "myId",
  }

``
<img width="136" alt="Capture d’écran 2022-03-25 à 16 39 46" src="https://user-images.githubusercontent.com/19576344/160153289-ab5ae3e1-696d-4eec-82f2-5de7a05ce337.png">
`