### PR TITLE
Fix configureFonts bindings

### DIFF
--- a/src/Paper__ThemeProvider.res
+++ b/src/Paper__ThemeProvider.res
@@ -38,8 +38,17 @@ module Theme = {
       fontWeight: string,
     }
 
+    @deriving(abstract)
+    type fontByOS = {
+      ios: t,
+      web: t,
+      android: t,
+      @optional macos: t,
+      @optional windows: t,
+    }
+
     @module("react-native-paper")
-    external configureFonts: t => configured = "configureFonts"
+    external configureFonts: fontByOS => configured = "configureFonts"
 
     @obj
     external make: (~regular: font, ~medium: font, ~light: font, ~thin: font) => t = ""


### PR DESCRIPTION
To configure fonts, you have to [specify the font per platform](https://callstack.github.io/react-native-paper/fonts.html)